### PR TITLE
3 user story

### DIFF
--- a/app/controllers/bulk_discounts_controller.rb
+++ b/app/controllers/bulk_discounts_controller.rb
@@ -23,7 +23,13 @@ class  BulkDiscountsController < ApplicationController
       flash.notice = "Please complete all fields to continue."
       render :new
     end
+  end
 
+  def destroy
+    @merchant = Merchant.find(params[:merchant_id])
+    BulkDiscount.find(params[:id]).destroy
+    flash.notice = "Your Discount Has Been Deleted"
+    redirect_to merchant_bulk_discounts_path(@merchant)
   end
 
   private

--- a/app/views/bulk_discounts/index.html.erb
+++ b/app/views/bulk_discounts/index.html.erb
@@ -6,9 +6,12 @@
   </div>
 
 <% @bulk_discounts.each do |discount| %>
+  <div id=<%= "discount-#{discount.id}" %>>
   <h3><%= link_to "Discount #{discount.id}", merchant_bulk_discount_path(@merchant, discount) %></h3>
   <p><%= discount.percentage_discount %>% OFF
   when you buy <%= discount.quantity_threshold %> or more of an item</p>
+  <%= button_to "Delete", merchant_bulk_discount_path(@merchant, discount), method: :delete %>
+  </div>
 <% end %>
 
 <br>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,7 +4,7 @@ Rails.application.routes.draw do
     resources :items, except: [:destroy]
     resources :item_status, only: [:update]
     resources :invoices, only: [:index, :show, :update]
-    resources :bulk_discounts, only: [:index, :show, :new, :create]
+    resources :bulk_discounts, only: [:index, :show, :new, :create, :destroy]
   end
 
   namespace :admin do

--- a/spec/features/bulk_discounts/index_spec.rb
+++ b/spec/features/bulk_discounts/index_spec.rb
@@ -79,4 +79,47 @@ RSpec.describe "Bulk Discounts Index Page" do
     click_button "Add New Discount"
     expect(current_path).to eq(new_merchant_bulk_discount_path(@merchant1))
   end
+
+  describe "delete button" do
+    it "has a button next to each bulk discount to delete it" do
+      within "#discount-#{@discount_1.id}" do
+      expect(page).to have_button("Delete")
+      end
+
+      within "#discount-#{@discount_2.id}" do
+      expect(page).to have_button("Delete")
+      end
+
+      within "#discount-#{@discount_3.id}" do
+      expect(page).to have_button("Delete")
+      end
+    end
+
+    it "removes the discount from the index page" do
+      expect(page).to have_content(@discount_3.id)
+      within "#discount-#{@discount_3.id}" do
+        click_button "Delete"
+      end
+
+      expect(page).to_not have_content(@discount_3.id)
+    end
+
+    it "redirects the user back to the bulk discounts index page and displays flash notice" do
+      within "#discount-#{@discount_3.id}" do
+        click_button "Delete"
+      end
+
+      expect(current_path).to eq(merchant_bulk_discounts_path(@merchant1))
+      expect(page).to have_content("Your Discount Has Been Deleted")
+    end
+  end 
 end
+
+# 3: Merchant Bulk Discount Delete
+
+# As a merchant
+# When I visit my bulk discounts index
+# Then next to each bulk discount I see a link to delete it
+# When I click this link
+# Then I am redirected back to the bulk discounts index page
+# And I no longer see the discount listed


### PR DESCRIPTION
Add testing and functionality for user story 3

3: Merchant Bulk Discount Delete

As a merchant
When I visit my bulk discounts index
Then next to each bulk discount I see a link to delete it
When I click this link
Then I am redirected back to the bulk discounts index page
And I no longer see the discount listed