### PR TITLE
5 user story

### DIFF
--- a/app/controllers/bulk_discounts_controller.rb
+++ b/app/controllers/bulk_discounts_controller.rb
@@ -32,6 +32,24 @@ class  BulkDiscountsController < ApplicationController
     redirect_to merchant_bulk_discounts_path(@merchant)
   end
 
+  def edit
+    @merchant = Merchant.find(params[:merchant_id])
+    @bulk_discount = BulkDiscount.find(params[:id])
+  end
+  
+  def update
+    @merchant = Merchant.find(params[:merchant_id])
+    @bulk_discount = BulkDiscount.find(params[:id])
+    
+    if @bulk_discount.update(bulk_discount_params)
+      redirect_to merchant_bulk_discount_path(@merchant, @bulk_discount)
+      flash.notice = "Discount #{@bulk_discount.id} has been successfully updated!"
+    else
+      flash.notice = "Enter valid updates to continue."
+      render :edit
+    end
+  end
+
   private
 
   def new_bulk_discount_params

--- a/app/views/bulk_discounts/edit.html.erb
+++ b/app/views/bulk_discounts/edit.html.erb
@@ -1,0 +1,13 @@
+<%= render partial: "shared/nav" %>
+
+
+<div class="row">Edit Discount <%= @bulk_discount.id %> </p>
+</div>
+
+<%= form_with model: @bulk_discount, url: merchant_bulk_discount_path(@merchant, @bulk_discount) do |f| %>
+  <%= f.label :percentage_discount %>
+  <%= f.text_field :percentage_discount %>
+  <%= f.label :quantity_threshold %>
+  <%= f.text_field :quantity_threshold %>
+  <%= f.submit "Update" %>
+<% end %>

--- a/app/views/bulk_discounts/show.html.erb
+++ b/app/views/bulk_discounts/show.html.erb
@@ -7,3 +7,5 @@
 <h2>Details</h2>
   <p>Percentage Discount: <%= @bulk_discount.percentage_discount %>% OFF</p>
   <p>Quantity Threshold: <%= @bulk_discount.quantity_threshold %> or more items</p>
+
+<p><%= link_to "Edit", edit_merchant_bulk_discount_path(@merchant, @bulk_discount) %></p>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,7 +4,7 @@ Rails.application.routes.draw do
     resources :items, except: [:destroy]
     resources :item_status, only: [:update]
     resources :invoices, only: [:index, :show, :update]
-    resources :bulk_discounts, only: [:index, :show, :new, :create, :destroy]
+    resources :bulk_discounts, only: [:index, :show, :new, :create, :destroy, :edit, :update]
   end
 
   namespace :admin do


### PR DESCRIPTION
Add testing and functionality for user story 5:

**Merchant Bulk Discount Edit**

As a merchant
When I visit my bulk discount show page
Then I see a link to edit the bulk discount
When I click this link
Then I am taken to a new page with a form to edit the discount
And I see that the discounts current attributes are pre-poluated in the form
When I change any/all of the information and click submit
Then I am redirected to the bulk discount's show page
And I see that the discount's attributes have been updated